### PR TITLE
chore: bump minor version to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.3...HEAD
+[0.0.4]: https://github.com/petercoulton/theid/releases/tag/0.0.4
 [0.0.3]: https://github.com/petercoulton/theid/releases/tag/0.0.3
 [0.0.2]: https://github.com/petercoulton/theid/releases/tag/0.0.2
 [0.0.1]: https://github.com/petercoulton/theid/releases/tag/0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.4] - 2020-10-20
 
-- Add Marketplace icon from [@ashatch](https://github.com/ashatch)
+### Added
+
+- Marketplace icon from [@ashatch](https://github.com/ashatch)
 
 ## [0.0.3] - 2020-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2020-10-20
+
+- Add Marketplace icon from [@ashatch](https://github.com/ashatch)
+
 ## [0.0.3] - 2020-10-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ Adds useful ID generators to VS Code:
 
 + Add Marketplace icon from [@ashatch](https://github.com/ashatch)
 
+See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.

--- a/README.md
+++ b/README.md
@@ -27,4 +27,8 @@ Adds useful ID generators to VS Code:
 ### 0.0.3
 
 + Update README
-+ 
+
+### 0.0.4
+
++ Add Marketplace icon from [@ashatch](https://github.com/ashatch)
+


### PR DESCRIPTION
This includes the marketplace icon changes from @ashatch. I merged the PR for those changes before I pushed the v0.0.3 changes, so I had to revert the merge and re-merge manuallly.
